### PR TITLE
Remove browser action

### DIFF
--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -4,9 +4,7 @@
   "version": "0.0.2",
   "description": "Resolve .idk domains using the URL provided by the Wikipedia page for a given topic",
   "homepage_url": "https://github.com/aaronjanse/dns-over-wikipedia",
-  "browser_action": {
-    "browser_style": false
-  },
+
   "background": {
     "scripts": ["common.js"]
   },


### PR DESCRIPTION
You are currently not using the browser action, therefore I removed it (its optional for both Chrome & Firefox).
I am probably not the only one who would be annoyed by a useless button that doesn't do anything when clicked on.
Good luck with you extension!