### PR TITLE
Redirect correctly when URL matches multiple rows

### DIFF
--- a/browser-extension/common.js
+++ b/browser-extension/common.js
@@ -17,7 +17,13 @@ function redirect(searchQuery) {
   var wikiUrlRow = infoboxRows.filter(x => x.innerText.match(/(?:URL)|(?:Website)/));
 
   if (wikiUrlRow[0]) {
-    return wikiUrlRow[0].querySelector('a').href;
+    for (var i in wikiUrlRow) {
+      var a = wikiUrlRow[i].querySelector('a');
+      if (a) {
+        return a.href;
+      }
+    }
+    return wikiUrl;
   } else {
     return wikiUrl;
   }

--- a/browser-extension/testcases.txt
+++ b/browser-extension/testcases.txt
@@ -1,0 +1,1 @@
+virustotal.idk


### PR DESCRIPTION
We find the row in infobox with URL by regex matching on URL or Website.
This commit handles the edge case that some infoboxes mentions URL or
Website before the actual URL row.
The test case is recorded in a new testcases.txt file.